### PR TITLE
Store hue key

### DIFF
--- a/AudioReader/Src/HueController.cs
+++ b/AudioReader/Src/HueController.cs
@@ -50,7 +50,10 @@ namespace AudioReader
 
             //Dictionary<string, string> hueKeyConfig = IniParser.GetSectionParameter("philips_hue");
             if (!Config.Get("philips_hue/key", out _key))
+            {
                 _key = _client.RegisterAsync("mypersonalappname", "mydevicename").GetAwaiter().GetResult();
+                Config.Set("philips_hue/key", _key);
+            }
 
             _client.Initialize(_key);
 


### PR DESCRIPTION
This closes #24.

If no hue api key was found in the config and a new one was generated, store the new one in the config.