### PR TITLE
Add typed config functions

### DIFF
--- a/AudioReader/Src/Config.cs
+++ b/AudioReader/Src/Config.cs
@@ -17,16 +17,31 @@ namespace AudioReader
             _doc.Load("Config/config.xml");
         }
 
-        public static bool Get(string property, out string value)
+        public static bool Get<T>(string property, out T value)
         {
-            value = "";
+            value = default(T);
+            string valueString = "";
 
             XmlNode node = _doc.SelectSingleNode("/config/" + property);
 
-            if (node == null) return false;
+            if (node == null)
+            {
+                Log.Warn("Config", "Tried to read property which doesn't exist: " + property);
+                return false;
+            }
 
-            value = node.InnerText;
-            return true;
+            valueString = node.InnerText;
+
+            try
+            {
+                value = (T)Convert.ChangeType(valueString, typeof(T));
+                return true;
+            }
+            catch (Exception)
+            {
+                Log.Warn("Config", "Could not convert property " + property + " with value " + valueString + " to type " + typeof(T).Name + ".");
+                return false;
+            }
         }
 
         public static bool Set(string property, object value)

--- a/AudioReader/Src/GlslRenderer.cs
+++ b/AudioReader/Src/GlslRenderer.cs
@@ -246,8 +246,8 @@ namespace AudioReader
             Mouse.Move += _mouseMove;
             Keyboard.KeyDown += _keyDown;
 
-            if (Config.Get("glsl/resolution", out string resolution))
-                _textureResolution = Int32.Parse(resolution);
+            if (Config.Get("glsl/resolution", out int resolution))
+                _textureResolution = resolution;
 
             BeatDetection.BeatDetected += (object sender, EventArgs e) =>
             {

--- a/AudioReader/Src/HueController.cs
+++ b/AudioReader/Src/HueController.cs
@@ -19,7 +19,7 @@ namespace AudioReader
         private ILocalHueClient _client;
         private IEnumerable<Group> _groups;
 
-        private bool _preserveColor;
+        private bool _preserveColor = false;
 
         private LightCommand _beatCommand;
         private LightCommand _defaultCommand;
@@ -66,10 +66,9 @@ namespace AudioReader
             _defaultCommand.Brightness = 20;
             _defaultCommand.TransitionTime = new TimeSpan(0);
             _defaultCommand.Saturation = 255;
-
-            string preserveColor;
-            Config.Get("philips_hue/preserve_color", out preserveColor);
-            _preserveColor = Convert.ToBoolean(preserveColor);
+            
+            if(Config.Get("philips_hue/preserve_color", out bool preserveColor))
+                _preserveColor = preserveColor;
 
             _groups = _client.GetGroupsAsync().GetAwaiter().GetResult().Where((g) => g.Type == GroupType.Room);
         }

--- a/AudioReader/Src/Program.cs
+++ b/AudioReader/Src/Program.cs
@@ -19,12 +19,12 @@ namespace AudioReader
         {
             Log.Enable(Log.LogLevel.Verbose);
 
-            if (!Config.Get("audio/arraysize", out string arraySize))
-                arraySize = "2048";
-            _data = new float[Int32.Parse(arraySize)];
-            if (!Config.Get("audio/reduced_arraysize", out string reducedArraySize))
-                arraySize = "128";
-            _reducedData = new float[Int32.Parse(reducedArraySize)];
+            if (!Config.Get("audio/arraysize", out int arraySize))
+                arraySize = 2048;
+            _data = new float[arraySize];
+            if (!Config.Get("audio/reduced_arraysize", out int reducedArraySize))
+                reducedArraySize = 128;
+            _reducedData = new float[reducedArraySize];
 
             _checkEnabled("audio", "AudioReader", () =>
             {
@@ -53,7 +53,7 @@ namespace AudioReader
 
         private static void _checkEnabled(string xmlName, string logName, Action enabledCallback)
         {
-            bool enabled = Config.Get(xmlName + "/enabled", out string enabledOut) && bool.Parse(enabledOut);
+            bool enabled = Config.Get(xmlName + "/enabled", out bool enabledOut) && enabledOut;
             Log.Info("Main", logName + (enabled ? " is enabled." : " is disabled."));
             if (enabled)
                 enabledCallback.Invoke();


### PR DESCRIPTION
This closes #35.

The config getter function now is able to return other types than just strings.